### PR TITLE
Fix for ppa:ondrej/apache2 and apache2-mpm-event conflicting

### DIFF
--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -38,7 +38,7 @@ sudo apt-get update
 
 # Install Apache
 # -qq implies -y --force-yes
-sudo apt-get install -qq apache2 apache2-mpm-event
+sudo apt-get install -qq apache2
 
 echo ">>> Configuring Apache"
 

--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -46,11 +46,11 @@ echo ">>> Configuring Apache"
 sudo usermod -a -G www-data vagrant
 
 # Apache Config
-# On separate lines since some may cause an error 
+# On separate lines since some may cause an error
 # if not installed
-sudo a2dismod mpm_prefork
-sudo a2dismod php5 
-sudo a2enmod mpm_worker rewrite actions ssl
+sudo a2dismod mpm_prefork mpm_worker
+sudo a2dismod php5
+sudo a2enmod rewrite actions ssl
 curl --silent -L $github_url/helpers/vhost.sh > vhost
 sudo chmod guo+x vhost
 sudo mv vhost /usr/local/bin


### PR DESCRIPTION
With the latest of ppa:ondrej/apache2 when installing apache2, the mpm-event module is enabled by default and the independent package of apache2-mpm-event is not needed and will cause compatibility issues if tried to install.

Also move mpm-worker to be disabled since mpm-event is enabled by default.
